### PR TITLE
Fixed a bug improving compatibility with node > v0.10.x

### DIFF
--- a/lib/quickthumb.js
+++ b/lib/quickthumb.js
@@ -56,7 +56,7 @@
 
         return function (req, res, next){
             var file = req.url.replace(/\?.*/,''),
-                dim = req.query.dim,
+                dim = req.query.dim || "",
                 orig = path.normalize(root + file),
                 dst = path.join(cache_root, options.type, dim, file);
 


### PR DESCRIPTION
_path.join()_ in Node v0.10.x+ requires the parameters to be String, otherwise throws an error

Here is more detail in the docs
http://nodejs.org/api/path.html#path_path_join_path1_path2

Follow these steps to reproduce the issue
1. Install [nave](https://github.com/isaacs/nave) or [nvm](https://github.com/creationix/nvm)
2. Use a node version > 0.10.x
3. Run the Express test `node test/express-test.js`

_Stack trace_

```
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at Object.handle (/Users/detj/Projects/node-quickthumb/lib/quickthumb.js:61:28)
    at next (/Users/detj/Projects/node-quickthumb/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at Object.expressInit [as handle] (/Users/detj/Projects/node-quickthumb/node_modules/express/lib/middleware.js:30:5)
    at next (/Users/detj/Projects/node-quickthumb/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at Object.query [as handle] (/Users/detj/Projects/node-quickthumb/node_modules/express/node_modules/connect/lib/middleware/query.js:44:5)
    at next (/Users/detj/Projects/node-quickthumb/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at Function.app.handle (/Users/detj/Projects/node-quickthumb/node_modules/express/node_modules/connect/lib/proto.js:198:3)
```
