### PR TITLE
Added cache update if original file has been changed.

### DIFF
--- a/lib/quickthumb.js
+++ b/lib/quickthumb.js
@@ -74,7 +74,17 @@ qt.static = function(root, options){
                         console.error(err);
                     }
                     else if (stats.isFile()){
-                        return sendfile(res, file);
+                        // Check if the original image has been changed since the cache file
+                        // was created and if so, recreate it, otherwise send cached file.
+                        fs.stat(orig, function (err, origStats) {
+                            if (err) {
+                                console.error(err);
+                            } else if (origStats.mtime.getTime() > stats.mtime.getTime()) {
+                                return callback();
+                            }
+
+                            return sendfile(res, file);
+                        });
                     }
                     callback();
                 });


### PR DESCRIPTION
Check if the original image has been changed since the cache file was created and if so, recreate it, otherwise send cached file.