### PR TITLE
Added -auto-orient options

### DIFF
--- a/lib/quickthumb.js
+++ b/lib/quickthumb.js
@@ -1,4 +1,4 @@
-var qt = {},
+﻿var qt = {},
     fs = require('fs'),
     path = require('path'),
     mkdirp = require('mkdirp'),
@@ -33,8 +33,8 @@ qt.convert = function(options, callback){
     if (options.width) im_options.width = width;
     if (options.height) im_options.height = height;
     if (options.quality) im_options.quality = quality;
-    
-    im_options.customArgs = ['-auto_orient'];
+
+    im_options.customArgs = ['-auto-orient'];
 
     try{
         im[type](im_options, function(err, stdout, stderr){

--- a/lib/quickthumb.js
+++ b/lib/quickthumb.js
@@ -33,6 +33,8 @@ qt.convert = function(options, callback){
     if (options.width) im_options.width = width;
     if (options.height) im_options.height = height;
     if (options.quality) im_options.quality = quality;
+    
+    im_options.customArgs = ['-auto_orient'];
 
     try{
         im[type](im_options, function(err, stdout, stderr){


### PR DESCRIPTION
-auto-orient option in imagemagick avoid to loose EXIF information in image, and keep portrait picture as portrait picture. Resolved #4.
(more info : http://www.imagemagick.org/discourse-server/viewtopic.php?t=12998)
