### PR TITLE
replace imagemagick github path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "resize"
   ],
   "dependencies": {
-    "imagemagick": "git://github.com/rsms/node-imagemagick.git",
+    "imagemagick": "git://github.com/yourdeveloper/node-imagemagick.git",
     "mkdirp": "~0.3.3"
   }
 }


### PR DESCRIPTION
There is a dependency to imagemagick but original github's module is abandoned.
So I replace it by the currently maintained version.